### PR TITLE
fix youtube livestream search sometimes not working

### DIFF
--- a/twitch-content.js
+++ b/twitch-content.js
@@ -396,7 +396,7 @@
         try {
             const response = await chrome.runtime.sendMessage({
                 type: 'SEARCH_YOUTUBE',
-                query: `${channelName} live`
+                query: channelName
             });
 
             if (!response || response.error) {


### PR DESCRIPTION
I've encountered a few times the search not finding a livestream, and while debugging the issue i found its because the extensions adds the word `live` to the search - which confuses the api when the livestream title doesn't includes this word

the search already is filtered for livestreams by adding `&sp=EgJAAQ%3D%3D` in the background script search url