### PR TITLE
feat: Add pog Alt+Y and Alt+T shortcuts & fix scuffed listener dupes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ A Chrome extension that lets you overlay any YouTube livestream on top of a Twit
 2. Go to any **Twitch Channel**
 3. Click the **▶ YouTube** button in the top navigation bar
 
+### ⌨️ Keyboard Shortcuts
+- **`Alt+Y`**: Quick-toggle the YouTube Player menu.
+- **`Alt+T`**: Quick-toggle Twitch Theater Mode.
+
 ### Finding a Stream
 - **Option A (Automatic)**: Click "🔍 Find YouTube Stream" to search for the streamer's YouTube live.
 - **Option B (Manual)**: Paste any YouTube URL (video, live, or embed link) and click "Go".

--- a/twitch-content.js
+++ b/twitch-content.js
@@ -716,7 +716,28 @@
         });
 
         document.addEventListener('keydown', (e) => {
+            // Ignore if typing in an input, textarea, or contenteditable
+            const activeElement = document.activeElement;
+            if (activeElement) {
+                const tagName = activeElement.tagName.toLowerCase();
+                if (tagName === 'input' || tagName === 'textarea' || activeElement.isContentEditable) {
+                    return;
+                }
+            }
+
             if (e.key === 'Escape') closeDropdown();
+
+            if (e.altKey && e.code === 'KeyY') {
+                e.preventDefault();
+                const dropdown = document.getElementById('ytot-dropdown');
+                if (dropdown) dropdown.classList.toggle('visible');
+            }
+
+            if (e.altKey && e.code === 'KeyT') {
+                e.preventDefault();
+                const theaterBtn = document.querySelector('[data-a-target="player-theater-mode-button"], button[aria-label*="Theater Mode" i]');
+                if (theaterBtn) theaterBtn.click();
+            }
         });
 
         globalListenersSetup = true;
@@ -876,21 +897,6 @@
     // Backup interval (slower check for robustness)
     setInterval(handleNavigation, 2000);
 
-    function setupGlobalListeners() {
-        // Close on click outside
-        document.addEventListener('click', (e) => {
-            const wrapper = document.getElementById('ytot-nav-wrapper');
-            if (wrapper && !wrapper.contains(e.target)) closeDropdown();
-        });
-
-        // Close on escape
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'Escape') closeDropdown();
-        });
-
-    }
-
-    setupGlobalListeners();
     setTimeout(check, 1000);
 
 })();


### PR DESCRIPTION
Implemented Quality of Life (QoL) keyboard shortcuts and fixed a duplicated listener function.

Changes:
1. **Shortcuts**: Added `Alt+Y` to toggle the extension menu and `Alt+T` to toggle Twitch's native Theater Mode.
2. **Chat Safety**: Added a guard clause to ignore the shortcuts if the user is actively focused on an `input`, `textarea`, or `contenteditable` element. This ensures the shortcuts don't fire while typing in Twitch chat.
3. **Cross-Platform Fix**: Used `e.code` (`KeyY` / `KeyT`) instead of `e.key` to ensure the shortcuts work correctly on macOS, where the Alt (Option) key acts as a character modifier.
4. **Cleanup**: Removed a redundant and incorrectly scoped `setupGlobalListeners` function that was declared a second time at the end of `twitch-content.js`.
5. **Documentation**: Added the new shortcuts to the `README.md` under the "Usage" section.

---
*PR created automatically by Jules for task [10310126374747112463](https://jules.google.com/task/10310126374747112463) started by @vrnrn*